### PR TITLE
Don't try to infer array length in NetStreamStorage constructor

### DIFF
--- a/c++/src/netstream-storage.cpp
+++ b/c++/src/netstream-storage.cpp
@@ -34,11 +34,8 @@ namespace netstream
 
 
 	// ----------------------------------------------------------------------
-	NetStreamStorage::NetStreamStorage(unsigned char packet[], int length)
+	NetStreamStorage::NetStreamStorage(unsigned char *packet, int length)
 	{
-		// Length is calculated, if -1, or given
-		if (length == -1) length = sizeof(packet) / sizeof(unsigned char);
-
 		store.reserve(length);
 		// Get the content
 		for(int i = 0; i < length; ++i) store.push_back(packet[i]);

--- a/c++/src/netstream-storage.h
+++ b/c++/src/netstream-storage.h
@@ -55,8 +55,8 @@ public:
 	/// Standard Constructor
 	NetStreamStorage();
 
-	/// Constructor, that fills the storage with an char array. If length is -1, the whole array is handed over
-	NetStreamStorage(unsigned char[], int length=-1);
+	/// Constructor, that fills the storage with an char array.
+	NetStreamStorage(unsigned char *, int length);
 
 	// Destructor
 	virtual ~NetStreamStorage();


### PR DESCRIPTION
Don't try to infer array length in NetStreamStorage constructor as this
is impossible and the implementation was flawed.

Sent you an email with the details.