### PR TITLE
Made python sender work with newer gs-core version

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,57 @@
+# Created by https://www.gitignore.io
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/python/example_sender.py
+++ b/python/example_sender.py
@@ -1,18 +1,19 @@
-from gs_netstream.sender import  NetStreamProxyGraph, NetStreamSender, Base64NetStreamTransport
+import logging
+from gs_netstream.sender import  NetStreamProxyGraph, NetStreamSender
 
-transport = Base64NetStreamTransport("default","localhost",2001)
-sender = NetStreamSender(transport)
+logging.basicConfig(level=logging.DEBUG)
+
+sender = NetStreamSender(2012)
 proxy = NetStreamProxyGraph(sender)
 
 style = "node{fill-mode:plain;fill-color:gray;size:1px;}"
-proxy.addAttribute("stylesheet", style)
+proxy.add_attribute("stylesheet", style)
 
-proxy.addAttribute("ui.antialias", True)
-proxy.addAttribute("layout.stabilization-limit", 0)
+proxy.add_attribute("ui.antialias", True)
+proxy.add_attribute("layout.stabilization-limit", 0)
 
 for i in range(0,500):
- proxy.addNode(str(i))
- if(i>0):
-   proxy.addEdge(str(i)+"_"+str(i-1), str(i), str(i-1),False)
-   proxy.addEdge(str(i)+"__"+str(i/2), str(i), str(i/2), False)
-   
+    proxy.add_node(str(i))
+    if i > 0:
+        proxy.add_edge(str(i) + "_" + str(i-1), str(i), str(i-1), False)
+        proxy.add_edge(str(i) + "__" + str(i/2), str(i), str(i/2), False)

--- a/python/gs_netstream/common.py
+++ b/python/gs_netstream/common.py
@@ -9,54 +9,50 @@ Copyright (c) 2011 University of Luxembourg. All rights reserved.
 
 import sys
 import os
-import unittest
-
 
 class AttributeSink(object):
-  def graphAttributeAdded(self, source_id, time_id, attribute, value):
-    raise NotImplementedError
-  
-  def graphAttributeChanged(self, source_id, time_id, attribute, old_value, new_value):
-    raise NotImplementedError
-  
-  def graphAttributeRemoved(self, source_id, time_id, attribute):
-    raise NotImplementedError
-  
-  def nodeAttributeAdded(self, source_id, time_id, node_id, attribute, value):
-    raise NotImplementedError
-  
-  def nodeAttributeChanged(self, source_id, time_id, node_id, attribute, old_value, new_value):
-    raise NotImplementedError
-  
-  def nodeAttributeRemoved(self, source_id, time_id, node_id, attribute):
-    raise NotImplementedError
-  
-  def edgeAttributeAdded(self, source_id, time_id, edge_id, attribute, value):
-    raise NotImplementedError
-  
-  def edgeAttributeChanged(self, source_id, time_id, edge_id, attribute, old_value, new_value):
-    raise NotImplementedError
-    
-  def edgeAttributeRemoved(self, source_id, time_id, edge_id, attribute):
-    raise NotImplementedError
+    def graph_attribute_added(self, source_id, time_id, attribute, value):
+        raise NotImplementedError
+
+    def graph_attribute_changed(self, source_id, time_id, attribute, old_value, new_value):
+        raise NotImplementedError
+
+    def graph_attribute_removed(self, source_id, time_id, attribute):
+        raise NotImplementedError
+
+    def node_attribute_added(self, source_id, time_id, node_id, attribute, value):
+        raise NotImplementedError
+
+    def node_attribute_changed(self, source_id, time_id, node_id, attribute, old_value, new_value):
+        raise NotImplementedError
+
+    def node_attribute_removed(self, source_id, time_id, node_id, attribute):
+        raise NotImplementedError
+
+    def edge_attribute_added(self, source_id, time_id, edge_id, attribute, value):
+        raise NotImplementedError
+
+    def edge_attribute_changed(self, source_id, time_id, edge_id, attribute, old_value, new_value):
+        raise NotImplementedError
+
+    def edge_attribute_removed(self, source_id, time_id, edge_id, attribute):
+        raise NotImplementedError
 
 class ElementSink(object):
-  def nodeAdded(self, source_id, time_id, node_id):
-    raise NotImplementedError
-  
-  def nodeRemoved(self, source_id, time_id, node_id):
-    raise NotImplementedError
-  
-  def edgeAdded(self, source_id, time_id, edge_id, from_node, to_node, directed):
-    raise NotImplementedError
-  
-  def edgeRemoved(self, source_id, time_id, edge_id):
-    raise NotImplementedError
-  
-  def graphCleared(self):
-    raise NotImplementedError
-  
-  def stepBegins(self, source_id, time_id, timestamp):
-    raise NotImplementedError
-  
+    def node_added(self, source_id, time_id, node_id):
+        raise NotImplementedError
 
+    def node_removed(self, source_id, time_id, node_id):
+        raise NotImplementedError
+
+    def edge_added(self, source_id, time_id, edge_id, from_node, to_node, directed):
+        raise NotImplementedError
+
+    def edge_removed(self, source_id, time_id, edge_id):
+        raise NotImplementedError
+
+    def step_begun(self, source_id, time_id, timestamp):
+        raise NotImplementedError
+
+    def graph_cleared(self, source_id, time_id):
+        raise NotImplementedError

--- a/python/gs_netstream/constants.py
+++ b/python/gs_netstream/constants.py
@@ -1,7 +1,7 @@
 """
-the NetStream constants module. 
+the NetStream constants module.
 
-Contains the constant bytes used in the protocol to identifie data types and events. 
+Contains the constant bytes used in the protocol to identifie data types and events.
 """
 
 """Followed by an 32-bit signed integer for this protocol version. Certainly useless."""
@@ -13,113 +13,104 @@ EVENT_START = 0x01
 """Not used."""
 EVENT_END = 0x02
 
-
 # ==============================
 # = GraphStream's graph events =
 # ==============================
- 
+
 """Followed by a node id (TYPE_STRING format)"""
 EVENT_ADD_NODE = 0x10
-	
 
 """Followed by a node id (TYPE_STRING format)"""
 EVENT_DEL_NODE = 0x11
-	
+
 """
-Followed by 
-  - an edge id (TYPE_STRING format), 
-  - an source node id (TYPE_STRING format), 
+Followed by
+  - an edge id (TYPE_STRING format),
+  - an source node id (TYPE_STRING format),
   - a target node id (TYPE_STRING format
-  - a boolean indicating if directed (TYPE_BOOLEAN format) 
+  - a boolean indicating if directed (TYPE_BOOLEAN format)
 """
 EVENT_ADD_EDGE = 0x12
-	
 
 """Followed by an edge id (TYPE_STRING format) """
 EVENT_DEL_EDGE = 0x13
-	
 
 """Followed by double (TYPE_DOUBLE format) """
 EVENT_STEP = 0x14
 
 EVENT_CLEARED = 0x15
-	
 
 """
-Followed by 
+Followed by
 - an attribute id (TYPE_STRING format)
 - the attribute TYPE
-- the attribute value 
+- the attribute value
 """
 EVENT_ADD_GRAPH_ATTR = 0x16
 
-
 """
-Followed by 
+Followed by
 - an attribute id (TYPE_STRING format)
 - the attribute TYPE
 - the attribute old value
-- the attribute new value 
+- the attribute new value
 """
 EVENT_CHG_GRAPH_ATTR = 0x17
 
 """
-Followed by 
+Followed by
 - the attribute id (TYPE_STRING format)
 """
 EVENT_DEL_GRAPH_ATTR = 0x18
-	
 
 """
-Followed by 
+Followed by
 - an attribute id (TYPE_STRING format)
 - the attribute TYPE
-- the attribute value 
+- the attribute value
 """
 EVENT_ADD_NODE_ATTR = 0x19
 
 """
-Followed by 
+Followed by
 - an attribute id (TYPE_STRING format)
 - the attribute TYPE
 - the attribute old value
-- the attribute new value 
+- the attribute new value
 """
 EVENT_CHG_NODE_ATTR = 0x1a
 
 """
-Followed by 
+Followed by
 - the node id (TYPE_STRING format)
 - the attribute id (TYPE_STRING format)
 """
 EVENT_DEL_NODE_ATTR = 0x1b
-	
-	
 
 """
-Followed by 
+Followed by
 - an attribute id (TYPE_STRING format)
 - the attribute TYPE
-- the attribute value 
+- the attribute value
 """
 EVENT_ADD_EDGE_ATTR = 0x1c
 
 """
-Followed by 
+Followed by
 - an attribute id (TYPE_STRING format)
 - the attribute TYPE
 - the attribute old value
-- the attribute new value 
+- the attribute new value
 """
 EVENT_CHG_EDGE_ATTR = 0x1d
 
 """
-Followed by 
+Followed by
 - the edge id (TYPE_STRING format)
 - the attribute id (TYPE_STRING format)
 """
 EVENT_DEL_EDGE_ATTR = 0x1e
-	
+
 # ===============
 # = Value Types =
 # ===============
@@ -128,14 +119,14 @@ EVENT_DEL_EDGE_ATTR = 0x1e
 Followed by a byte who's value is 0 or 1
 """
 TYPE_BOOLEAN = 0x50
- 
+
 """
 An array of booleans. Followed by first, a 16-bits integer for the number
 of booleans and then, a list of bytes who's value is 0 or 1
 """
 TYPE_BOOLEAN_ARRAY = 0x51
 
-"""Followed by a signed byte [-127,127]""" 
+"""Followed by a signed byte [-127,127]"""
 TYPE_BYTE = 0x52
 
 """
@@ -169,7 +160,7 @@ TYPE_LONG = 0x58
 
 """
 An array of longs. Followed by first, a 16-bits integer for the number of
-longs and then, a list of 62-bit signed integers
+longs and then, a list of 64-bit signed integers
 """
 TYPE_LONG_ARRAY = 0x59
 
@@ -186,7 +177,6 @@ TYPE_FLOAT_ARRAY = 0x5b
 
 """Followed by a double precision 64-bits floating point number"""
 TYPE_DOUBLE = 0x5c
-
 
 """
 Array of double. Followed by first, a 16-bits integer for the number of
@@ -206,11 +196,10 @@ Raw data, good for serialization. Followed by first, a 16-bits integer
 indicating the length in bytes of the dataset, and then the data itself.
 """
 TYPE_RAW = 0x5f
-	
+
 """
 An type-unspecified array. Followed by first, a
 16-bits integer indicating the number of elements, and then, the elements
 themselves. The elements themselves have to give their type.
 """
 TYPE_ARRAY = 0x60
-

--- a/python/gs_netstream/sender.py
+++ b/python/gs_netstream/sender.py
@@ -8,492 +8,590 @@ This module implements a NetStream Sender
 Created by Yoann Pigné on 2011-08-20.
 Copyright (c) 2011 University of Luxembourg. All rights reserved.
 
+Heavily modified to work with new GraphStream core versions.
+Hugo Hromic <hugo.hromic@insight-centre.org>
 """
 
 import socket
 import struct
-import types
-import base64
+import varint
+import logging
 from random import random
 from common import AttributeSink, ElementSink
 from constants import *
 
+class DefaultNetStreamTransport(object):
+    """Default transport class using TCP/IP networking."""
+    def __init__(self, host, port):
+        """Initialize using host and port."""
+        self.host = host
+        self.port = port
+        self.socket = None
 
-class NetStreamTransport(object):
-   """Defines the general behaviour of the class that will be in charge of the actuall data sending"""
-   
-   def __init__(self, stream, host, port):
-      raise NotImplementedError
-   def connect(self):
-      raise NotImplementedError      
-   
-class DefaultNetStreamTransport(NetStreamTransport):
-   stream="Default"
-   host="localhost"
-   port=2001
-   socket=None
- 
-   def __init__(self, stream, host, port):
-      self.stream = stream
-      self.stream_string=struct.pack("!i",len(stream))+stream
-      self.host = host
-      self.port = port
-   
-   def connect(self):
-     self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-     self.socket.connect((self.host, self.port))
-   
-   def send(self, event):
-      if(self.socket == None):
-         self.connect()
-      self.socket.sendall(struct.pack("!i",+len(self.stream_string)+len(event))+self.stream_string+event)
-   
-   
-class Base64NetStreamTransport(NetStreamTransport):
-   stream="Default"
-   host="localhost"
-   port=2001
-   socket=None
+    def connect(self):
+        """Connect to remote server if necessary."""
+        if not self.socket:
+            self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.socket.connect((self.host, self.port))
+            logging.info("connected to remote server")
 
-   def __init__(self, stream, host, port):
-      self.stream = stream
-      self.stream_string=struct.pack("!i",len(stream))+stream
-      self.host = host
-      self.port = port
+    def send(self, data):
+        """Send data to remote server."""
+        if not self.socket:
+            self.connect()
+        try:
+            self.socket.sendall(data)
+        except socket.error as err:
+            self.socket = None
+            logging.error(err)
 
-   def connect(self):
-      self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-      self.socket.connect((self.host, self.port))
+    def close(self):
+        """Close the connection."""
+        if self.socket:
+            self.socket.close()
+            self.socket = None
+            logging.info("disconnected from remote server")
 
-   def send(self, event):
-      if(self.socket == None):
-         self.connect()
-      encoded_msg = base64.b64encode(self.stream_string+event)
-      self.socket.sendall(base64.b64encode(struct.pack("!i",len(encoded_msg)))+encoded_msg)
+class NetStreamSender(AttributeSink, ElementSink):
+    """One client must send to only one identified stream (streamID, host, port)"""
 
+    def __init__(self, port, host="localhost", stream="default"):
+        """Initialize using port, host (optional) and stream ID (optional)."""
+        self.host = host
+        self.port = port
+        self.stream = None
+        self.stream_buff = None
+        self.set_stream(stream)
+        self.source_id = None
+        self.source_id_buff = None
+        self.set_source_id("")
+        self.transport = None
+        self.connect()
 
+    def set_stream(self, stream):
+        """Set and cache a stream ID."""
+        self.stream = stream
+        self.stream_buff = self.encode_string(stream)
 
-class NetStreamSender(AttributeSink,ElementSink):
-  """One client must send to only one identified stream (streamID, host, port)"""
+    def set_source_id(self, source_id):
+        """Set and cache a source ID."""
+        self.source_id = source_id
+        self.source_id_buff = self.encode_string(source_id)
 
-  transport = None
-  
-  
-  def __init__(self, *args, **kwargs):
-     """Constructor can be with one NetStreamTransport object OR with 3 args: Stream ID, Host, and port number"""
-     if len(args) == 1 and isinstance(args[0], NetStreamTransport):
-        print("Initialize from transport object")
-        self.init_from_transport(args[0])
-     else:
-        if len(args) == 3 and isinstance(args[0], types.StringType) and isinstance(args[1], types.StringType) and isinstance(args[2], types.IntType):
-           print("Initialize from args")
-           self.init_from_args(args[0], args[1], args[2])
-        else:
-           print("Impossible to Initialize")
-           
-  def init_from_args(self, stream, host, port):
-    self.transport = DefaultNetStreamTransport(stream, host,port)
-    self.transport.connect();
-    
-  def init_from_transport(self,transport):
-     self.transport = transport
-  
-  def encode_string(self, string):
-    """Encodes a given string"""
-    return struct.pack("!i",len(string))+string
-  
-  def _getType(self, value):
-    is_array = isinstance(value,types.ListType)
-    if is_array:
-      value = value[0]
-    if isinstance(value, types.BooleanType):
-      if is_array:
-        return TYPE_BOOLEAN_ARRAY
-      else:
-        return TYPE_BOOLEAN
-    elif isinstance(value, types.IntType):
-      if is_array:
-        return TYPE_INT_ARRAY
-      else:
-        return TYPE_INT
-    elif isinstance(value, types.LongType):
-      if is_array:
-        return TYPE_LONG_ARRAY
-      else:
-        return TYPE_LONG
-    elif isinstance(value, types.FloatType):
-      if is_array:
-        return TYPE_DOUBLE_ARRAY
-      else:
-        return TYPE_DOUBLE
-    elif isinstance(value, types.StringType) or isinstance(value, types.UnicodeType):
-      return TYPE_STRING
-    elif isinstance(value, types.DictType):
-      raise NotImplementedError("You tried to send a dictionary through the NetStream Protocol, though it is not yet implemented.")
-  
-  def _encodeValue(self, value, value_type):
-    if TYPE_BOOLEAN == value_type:
-      return self._encodeBoolean(value)
-    elif TYPE_BOOLEAN_ARRAY == value_type:
-      return self._encodeBooleanArray(value)
-    elif TYPE_INT == value_type:
-      return self._encodeInt(value)
-    elif TYPE_INT_ARRAY == value_type:
-      return self._encodeIntArray(value)
-    elif TYPE_LONG == value_type:
-      return self._encodeLong(value)
-    elif TYPE_LONG_ARRAY == value_type:
-      return self._encodeLongArray(value)
-    elif TYPE_DOUBLE == value_type:
-      return self._encodeDouble(value)
-    elif TYPE_DOUBLE_ARRAY == value_type:
-      return self._encodeDoubleArray(value)
-    elif TYPE_STRING == value_type:
-      return self._encodeString(value);
-    return None
-  
-  def _encodeString(self, value):
-    return struct.pack("!i",len(value))+value
+    def connect(self):
+        """Connect to the underlying transport."""
+        self.transport = DefaultNetStreamTransport(self.host, self.port)
 
-  def _encodeDoubleArray(self, value):
-    if not isinstance(value, types.ListType) or not isinstance(value[0], types.FloatType):
-      raise TypeError("You've specified an incorrect type")
-    event = struct.pack("!i",len(value))  
-    for v in value:
-      if not isinstance(v,types.FloatType):
-        raise TypeError("You've specified an incorrect type")
-      event = event+struct.pack("!d",v)
-    return event
+    def send(self, event):
+        """Send a graph event to the remote server."""
+        packet = bytearray()
+        packet.extend(self.stream_buff)
+        packet.extend(event)
+        buff = bytearray()
+        buff.extend(struct.pack("!i", len(packet))) # fixed 4-bytes size!
+        buff.extend(packet)
+        self.transport.send(buff)
 
-  def _encodeDouble(self, value):
-    return struct.pack("!d",value)
+    def close(self):
+        """Close the underlying transport."""
+        if self.transport:
+            self.transport.close()
 
-  def _encodeLongArray(self, value):
-    if not isinstance(value, types.ListType) or not isinstance(value[0], types.LongType):
-      raise TypeError("You've specified an incorrect type")
-    event = struct.pack("!i",len(value))
-    for v in value:
-      if not isinstance(v,types.LongType):
-        raise TypeError("You've specified an incorrect type")
-      event = event+struct.pack("!q",v)
-    return event
-  
-  def _encodeLong(self, value):
-    return struct.pack("!q",value)
-  
-  def _encodeIntArray(self, value):
-    if not isinstance(value, types.ListType) or not isinstance(value[0], types.IntType):
-      raise TypeError("You've specified an incorrect type")
-    event = struct.pack("!i",len(value))
-    for v in value:
-      if not isinstance(v,types.IntType):
-        raise TypeError("You've specified an incorrect type")
-      event = event+struct.pack("!i",v)
-    return event
-  
-  def _encodeInt(self, value):
-    return struct.pack("!i",value)
+    def get_type(self, value):
+        """Get the data type for a given value."""
+        is_array = isinstance(value, list)
+        if is_array:
+            value = value[0]
+        if isinstance(value, bool):
+            if is_array:
+                return TYPE_BOOLEAN_ARRAY
+            return TYPE_BOOLEAN
+        elif isinstance(value, int):
+            if is_array:
+                return TYPE_INT_ARRAY
+            return TYPE_INT
+        elif isinstance(value, long):
+            if is_array:
+                return TYPE_LONG_ARRAY
+            return TYPE_LONG
+        elif isinstance(value, float):
+            if is_array:
+                return TYPE_DOUBLE_ARRAY
+            return TYPE_DOUBLE
+        elif isinstance(value, str) or isinstance(value, unicode):
+            return TYPE_STRING
+        elif isinstance(value, dict):
+            raise NotImplementedError("dicts are not supported")
 
-  
-  def _encodeBooleanArray(self, value):
-    if not isinstance(value, types.ListType) or not isinstance(value[0], types.BooleanType):
-      raise TypeError("You've specified an incorrect type")
-    event = struct.pack("!i",len(value))
-    for v in value:
-      if not isinstance(v,types.BooleanType):
-        raise TypeError("You've specified an incorrect type")
-      event = event+struct.pack("!?",v)
-    return event
-  
-  def _encodeBoolean(self, value):
-    return struct.pack("!?",value)
-  
-  def _encodeByte(self, value):
-    return struct.pack("!b",value)
-  
-  
-  # =========================
-  # = AttributeSink methods =
-  # =========================
-  def graphAttributeAdded(self, source_id, time_id, attribute, value):
-    event= self._encodeByte(EVENT_ADD_GRAPH_ATTR)
-    event = event + self._encodeString(source_id) + self._encodeLong(time_id)
-    event = event + self._encodeString(attribute)
-    type = self._getType(value) 
-    event = event + self._encodeByte(type)
-    event = event + self._encodeValue(value,type)
-    self.transport.send(event)
-  
-  def graphAttributeChanged(self, source_id, time_id, attribute, old_value, new_value):
-    event = self._encodeByte(EVENT_CHG_GRAPH_ATTR)
-    event = event + self._encodeString(source_id) + self._encodeLong(time_id)
-    event = event + self._encodeString(attribute)
-    type = self._getType(old_value)
-    event = event + self._encodeByte(type)
-    event = event + self._encodeValue(old_value,type)
-    type = self._getType(new_value)
-    event = event + self._encodeByte(type)
-    event = event + self._encodeValue(new_value,type)
-    self.transport.send(event)
-  
-  def graphAttributeRemoved(self, source_id, time_id, attribute):
-    event = self._encodeByte(EVENT_DEL_GRAPH_ATTR)
-    event = event + self._encodeString(source_id) + self._encodeLong(time_id)
-    event = event + self._encodeString(attribute)
-    self.transport.send(event)
-  
-  def nodeAttributeAdded(self, source_id, time_id, node_id, attribute, value):
-    event = self._encodeByte(EVENT_ADD_NODE_ATTR)
-    event = event + self._encodeString(source_id) + self._encodeLong(time_id)
-    event = event + self._encodeString(node_id)
-    event = event + self._encodeString(attribute)
-    type = self._getType(value)
-    event = event + self._encodeByte(type)
-    event = event + self._encodeValue(value,type)
-    self.transport.send(event)
-  
-  def nodeAttributeChanged(self, source_id, time_id, node_id, attribute, old_value, new_value):
-    event = self._encodeByte(EVENT_CHG_NODE_ATTR)
-    event = event + self._encodeString(source_id) + self._encodeLong(time_id)
-    event = event + self._encodeString(node_id)
-    event = event + self._encodeString(attribute)
-    type = self._getType(old_value)
-    event = event + self._encodeByte(type)
-    event = event + self._encodeValue(old_value,type)
-    type = self._getType(new_value)
-    event = event + self._encodeByte(type)
-    event = event + self._encodeValue(new_value,type)
-    self.transport.send(event)
-  
-  def nodeAttributeRemoved(self, source_id, time_id, node_id, attribute):
-    event = self._encodeByte(EVENT_DEL_NODE_ATTR)
-    event = event + self._encodeString(source_id) + self._encodeLong(time_id)
-    event = event + self._encodeString(node_id)
-    event = event + self._encodeString(attribute)
-    self.transport.send(event)
-  
-  def edgeAttributeAdded(self, source_id, time_id, edge_id, attribute, value):
-    event = self._encodeByte(EVENT_ADD_EDGE_ATTR)
-    event = event + self._encodeString(source_id) + self._encodeLong(time_id)
-    event = event + self._encodeString(edge_id)
-    event = event + self._encodeString(attribute)
-    type = self._getType(value)
-    event = event + self._encodeByte(type)
-    event = event + self._encodeValue(value,type)
-    self.transport.send(event)
-  
-  def edgeAttributeChanged(self, source_id, time_id, edge_id, attribute, old_value, new_value):
-    event = self._encodeByte(EVENT_CHG_EDGE_ATTR)
-    event = event + self._encodeString(source_id) + self._encodeLong(time_id)
-    event = event + self._encodeString(edge_id)
-    event = event + self._encodeString(attribute)
-    type = self._getType(old_value)
-    event = event + self._encodeByte(type)
-    event = event + self._encodeValue(old_value,type)
-    type = self._getType(new_value)
-    event = event + self._encodeByte(type)
-    event = event + self._encodeValue(new_value,type)
-    self.transport.send(event)
-  
-  def edgeAttributeRemoved(self, source_id, time_id, edge_id, attribute):
-    event = self._encodeByte(EVENT_DEL_EDGE_ATTR)
-    event = event + self._encodeString(source_id) + self._encodeLong(time_id)
-    event = event + self._encodeString(edge_id)
-    event = event + self._encodeString(attribute)
-    self.transport.send(event)
-  
-  def nodeAdded(self, source_id, time_id, node_id):
-    event = self._encodeByte(EVENT_ADD_NODE)
-    event = event + self._encodeString(source_id) + self._encodeLong(time_id)
-    event = event + self._encodeString(node_id)
-    self.transport.send(event)
-  
-  def nodeRemoved(self, source_id, time_id, node_id):
-    event = self._encodeByte(EVENT_DEL_NODE)
-    event = event + self._encodeString(source_id) + self._encodeLong(time_id)
-    event = event + self._encodeString(node_id)
-    self.transport.send(event)
-  
-  def edgeAdded(self, source_id, time_id, edge_id, from_node, to_node, directed):
-    event = self._encodeByte(EVENT_ADD_EDGE)
-    event = event + self._encodeString(source_id) + self._encodeLong(time_id)
-    event = event + self._encodeString(edge_id)
-    event = event + self._encodeString(from_node)
-    event = event + self._encodeString(to_node)
-    event = event + self._encodeBoolean(directed)
-    self.transport.send(event)
-  
-  def edgeRemoved(self, source_id, time_id, edge_id):
-    event = self._encodeByte(EVENT_DEL_EDGE)
-    event = event + self._encodeString(source_id) + self._encodeLong(time_id)
-    event = event + self._encodeString(edge_id)
-    self.transport.send(event)
-  
-  def graphCleared(self, source_id, time_id):
-    event = self._encodeByte(EVENT_CLEARED)
-    event = event + self._encodeString(source_id) + self._encodeLong(time_id)
-    self.transport.send(event)
-  
-  def stepBegins(self, source_id, time_id, timestamp):
-    event = self._encodeByte(EVENT_STEP)
-    event = event + self._encodeString(source_id) + self._encodeLong(time_id)
-    event = event + self._encodeDouble(timestamp)
-    self.transport.send(event)
+    def encode_value(self, value, dtype):
+        """Encode a value according to a given data type."""
+        if dtype is TYPE_BOOLEAN:
+            return self.encode_boolean(value)
+        elif dtype is TYPE_BOOLEAN_ARRAY:
+            return self.encode_boolean_array(value)
+        elif dtype is TYPE_INT:
+            return self.encode_int(value)
+        elif dtype is TYPE_INT_ARRAY:
+            return self.encode_int_array(value)
+        elif dtype is TYPE_LONG:
+            return self.encode_long(value)
+        elif dtype is TYPE_LONG_ARRAY:
+            return self.encode_long_array(value)
+        elif dtype is TYPE_DOUBLE:
+            return self.encode_double(value)
+        elif dtype is TYPE_DOUBLE_ARRAY:
+            return self.encode_double_array(value)
+        elif dtype is TYPE_STRING:
+            return self.encode_string(value)
+        return None
+
+    def encode_boolean(self, value):
+        """Encode a boolean type."""
+        return bytearray([value & 1])
+
+    def encode_boolean_array(self, value):
+        """Encode an array of boolean values."""
+        if not isinstance(value, list):
+            raise TypeError("value is not an array")
+        buff = bytearray()
+        buff.extend(varint.encode_unsigned(len(value)))
+        for elem in value:
+            if not isinstance(elem, bool):
+                raise TypeError("array element is not a boolean")
+            buff.extend(self.encode_boolean(elem))
+        return buff
+
+    def encode_int(self, value):
+        """Encode an integer type."""
+        return varint.encode_unsigned(value)
+
+    def encode_int_array(self, value):
+        """Encode an array of integer values."""
+        if not isinstance(value, list):
+            raise TypeError("value is not an array")
+        buff = bytearray()
+        buff.extend(varint.encode_unsigned(len(value)))
+        for elem in value:
+            if not isinstance(elem, int):
+                raise TypeError("array element is not an integer")
+            buff.extend(self.encode_int(elem))
+        return buff
+
+    def encode_long(self, value):
+        """Encode a long type."""
+        return self.encode_int(value) # same as int for now
+
+    def encode_long_array(self, value):
+        """Encode an array of long values."""
+        return self.encode_int_array(value) # same as int_array for now
+
+    def encode_double(self, value):
+        """Encode a double type."""
+        return bytearray(struct.pack("!d", value))
+
+    def encode_double_array(self, value):
+        """Encode an array of double values."""
+        if not isinstance(value, list):
+            raise TypeError("value is not an array")
+        buff = bytearray()
+        buff.extend(varint.encode_unsigned(len(value)))
+        for elem in value:
+            if not isinstance(elem, float):
+                raise TypeError("array element is not a float/double")
+            buff.extend(self.encode_double(elem))
+        return buff
+
+    def encode_string(self, string):
+        """Encode a string type."""
+        data = bytearray(string, "UTF-8")
+        buff = bytearray()
+        buff.extend(varint.encode_unsigned(len(data)))
+        buff.extend(data)
+        return buff
+
+    def encode_byte(self, value):
+        """Encode a byte type."""
+        return bytearray([value])
+
+    # =========================
+    # = AttributeSink methods =
+    # =========================
+
+    def node_added(self, source_id, time_id, node_id):
+        """A node was added."""
+        if not source_id is self.source_id:
+            self.set_source_id(source_id)
+        buff = bytearray()
+        buff.extend(self.encode_byte(EVENT_ADD_NODE))
+        buff.extend(self.encode_string(source_id))
+        buff.extend(self.encode_long(time_id))
+        buff.extend(self.encode_string(node_id))
+        self.send(buff)
+        logging.debug("node added: %s", {
+            "source_id": source_id,
+            "time_id": time_id,
+            "node_id": node_id
+        })
+
+    def node_removed(self, source_id, time_id, node_id):
+        """A node was removed."""
+        if not source_id is self.source_id:
+            self.set_source_id(source_id)
+        buff = bytearray()
+        buff.extend(self.encode_byte(EVENT_DEL_NODE))
+        buff.extend(self.encode_string(source_id))
+        buff.extend(self.encode_long(time_id))
+        buff.extend(self.encode_string(node_id))
+        self.send(buff)
+        logging.debug("node removed: %s", {
+            "source_id": source_id,
+            "time_id": time_id,
+            "node_id": node_id
+        })
+
+    def edge_added(self, source_id, time_id, edge_id, from_node, to_node, directed):
+        """An edge was added."""
+        if not source_id is self.source_id:
+            self.set_source_id(source_id)
+        buff = bytearray()
+        buff.extend(self.encode_byte(EVENT_ADD_EDGE))
+        buff.extend(self.encode_string(source_id))
+        buff.extend(self.encode_long(time_id))
+        buff.extend(self.encode_string(edge_id))
+        buff.extend(self.encode_string(from_node))
+        buff.extend(self.encode_string(to_node))
+        buff.extend(self.encode_boolean(directed))
+        self.send(buff)
+        logging.debug("edge added: %s", {
+            "source_id": source_id,
+            "time_id": time_id,
+            "edge_id": edge_id,
+            "from_node": from_node,
+            "to_node": to_node,
+            "directed": directed
+        })
+
+    def edge_removed(self, source_id, time_id, edge_id):
+        """An edge was removed."""
+        if not source_id is self.source_id:
+            self.set_source_id(source_id)
+        buff = bytearray()
+        buff.extend(self.encode_byte(EVENT_DEL_EDGE))
+        buff.extend(self.encode_string(source_id))
+        buff.extend(self.encode_long(time_id))
+        buff.extend(self.encode_string(edge_id))
+        self.send(buff)
+        logging.debug("edge removed: %s", {
+            "source_id": source_id,
+            "time_id": time_id,
+            "node_id": edge_id
+        })
+
+    def step_begun(self, source_id, time_id, timestamp):
+        """A new step begun."""
+        if not source_id is self.source_id:
+            self.set_source_id(source_id)
+        buff = bytearray()
+        buff.extend(self.encode_byte(EVENT_STEP))
+        buff.extend(self.encode_string(source_id))
+        buff.extend(self.encode_long(time_id))
+        buff.extend(self.encode_double(timestamp))
+        self.send(buff)
+        logging.debug("step begun: %s", {
+            "source_id": source_id,
+            "time_id": time_id,
+            "timestamp": timestamp
+        })
+
+    def graph_cleared(self, source_id, time_id):
+        """The graph was cleared."""
+        if not source_id is self.source_id:
+            self.set_source_id(source_id)
+        buff = bytearray()
+        buff.extend(self.encode_byte(EVENT_CLEARED))
+        buff.extend(self.encode_string(source_id))
+        buff.extend(self.encode_long(time_id))
+        self.send(buff)
+        logging.debug("graph cleared: %s", {
+            "source_id": source_id,
+            "time_id": time_id
+        })
+
+    def graph_attribute_added(self, source_id, time_id, attribute, value):
+        """A graph attribute was added."""
+        if not source_id is self.source_id:
+            self.set_source_id(source_id)
+        buff = bytearray()
+        buff.extend(self.encode_byte(EVENT_ADD_GRAPH_ATTR))
+        buff.extend(self.encode_string(source_id))
+        buff.extend(self.encode_long(time_id))
+        buff.extend(self.encode_string(attribute))
+        dtype = self.get_type(value)
+        buff.extend(self.encode_byte(dtype))
+        buff.extend(self.encode_value(value, dtype))
+        self.send(buff)
+        logging.debug("graph attribute added: %s", {
+            "source_id": source_id,
+            "time_id": time_id,
+            "attribute": attribute,
+            "value": value
+        })
+
+    def graph_attribute_changed(self, source_id, time_id, attribute, old_value, new_value):
+        """A graph attribute was changed."""
+        if not source_id is self.source_id:
+            self.set_source_id(source_id)
+        buff = bytearray()
+        buff.extend(self.encode_byte(EVENT_CHG_GRAPH_ATTR))
+        buff.extend(self.encode_string(source_id))
+        buff.extend(self.encode_long(time_id))
+        buff.extend(self.encode_string(attribute))
+        dtype = self.get_type(old_value)
+        buff.extend(self.encode_byte(dtype))
+        buff.extend(self.encode_value(old_value, dtype))
+        dtype = self.get_type(new_value)
+        buff.extend(self.encode_byte(dtype))
+        buff.extend(self.encode_value(new_value, dtype))
+        self.send(buff)
+        logging.debug("graph attribute changed: %s", {
+            "source_id": source_id,
+            "time_id": time_id,
+            "attribute": attribute,
+            "old_value": old_value,
+            "new_value": new_value
+        })
+
+    def graph_attribute_removed(self, source_id, time_id, attribute):
+        """A graph attribute was removed."""
+        if not source_id is self.source_id:
+            self.set_source_id(source_id)
+        buff = bytearray()
+        buff.extend(self.encode_byte(EVENT_DEL_GRAPH_ATTR))
+        buff.extend(self.encode_string(source_id))
+        buff.extend(self.encode_long(time_id))
+        buff.extend(self.encode_string(attribute))
+        self.send(buff)
+        logging.debug("graph attribute removed: %s", {
+            "source_id": source_id,
+            "time_id": time_id,
+            "attribute": attribute
+        })
+
+    def node_attribute_added(self, source_id, time_id, node_id, attribute, value):
+        """A node attribute was added."""
+        if not source_id is self.source_id:
+            self.set_source_id(source_id)
+        buff = bytearray()
+        buff.extend(self.encode_byte(EVENT_ADD_NODE_ATTR))
+        buff.extend(self.encode_string(source_id))
+        buff.extend(self.encode_long(time_id))
+        buff.extend(self.encode_string(node_id))
+        buff.extend(self.encode_string(attribute))
+        dtype = self.get_type(value)
+        buff.extend(self.encode_byte(dtype))
+        buff.extend(self.encode_value(value, dtype))
+        self.send(buff)
+        logging.debug("node attribute added: %s", {
+            "source_id": source_id,
+            "time_id": time_id,
+            "node_id": node_id,
+            "attribute": attribute,
+            "value": value
+        })
+
+    def node_attribute_changed(self, source_id, time_id, node_id, attribute, old_value, new_value):
+        """A node attribute was changed."""
+        if not source_id is self.source_id:
+            self.set_source_id(source_id)
+        buff = bytearray()
+        buff.extend(self.encode_byte(EVENT_CHG_NODE_ATTR))
+        buff.extend(self.encode_string(source_id))
+        buff.extend(self.encode_long(time_id))
+        buff.extend(self.encode_string(node_id))
+        buff.extend(self.encode_string(attribute))
+        dtype = self.get_type(old_value)
+        buff.extend(self.encode_byte(dtype))
+        buff.extend(self.encode_value(old_value, dtype))
+        dtype = self.get_type(new_value)
+        buff.extend(self.encode_byte(dtype))
+        buff.extend(self.encode_value(new_value, dtype))
+        self.send(buff)
+        logging.debug("node attribute changed: %s", {
+            "source_id": source_id,
+            "time_id": time_id,
+            "node_id": node_id,
+            "attribute": attribute,
+            "old_value": old_value,
+            "new_value": new_value
+        })
+
+    def node_attribute_removed(self, source_id, time_id, node_id, attribute):
+        """A node attribute was removed."""
+        if not source_id is self.source_id:
+            self.set_source_id(source_id)
+        buff = bytearray()
+        buff.extend(self.encode_byte(EVENT_DEL_NODE_ATTR))
+        buff.extend(self.encode_string(source_id))
+        buff.extend(self.encode_long(time_id))
+        buff.extend(self.encode_string(node_id))
+        buff.extend(self.encode_string(attribute))
+        self.send(buff)
+        logging.debug("node attribute removed: %s", {
+            "source_id": source_id,
+            "time_id": time_id,
+            "node_id": node_id,
+            "attribute": attribute
+        })
+
+    def edge_attribute_added(self, source_id, time_id, edge_id, attribute, value):
+        """An edge attribute was added."""
+        if not source_id is self.source_id:
+            self.set_source_id(source_id)
+        buff = bytearray()
+        buff.extend(self.encode_byte(EVENT_ADD_EDGE_ATTR))
+        buff.extend(self.encode_string(source_id))
+        buff.extend(self.encode_long(time_id))
+        buff.extend(self.encode_string(edge_id))
+        buff.extend(self.encode_string(attribute))
+        dtype = self.get_type(value)
+        buff.extend(self.encode_byte(dtype))
+        buff.extend(self.encode_value(value, dtype))
+        self.send(buff)
+        logging.debug("edge attribute added: %s", {
+            "source_id": source_id,
+            "time_id": time_id,
+            "edge_id": edge_id,
+            "attribute": attribute,
+            "value": value
+        })
+
+    def edge_attribute_changed(self, source_id, time_id, edge_id, attribute, old_value, new_value):
+        """An edge attribute was changed."""
+        if not source_id is self.source_id:
+            self.set_source_id(source_id)
+        buff = bytearray()
+        buff.extend(self.encode_byte(EVENT_CHG_EDGE_ATTR))
+        buff.extend(self.encode_string(source_id))
+        buff.extend(self.encode_long(time_id))
+        buff.extend(self.encode_string(edge_id))
+        buff.extend(self.encode_string(attribute))
+        dtype = self.get_type(old_value)
+        buff.extend(self.encode_byte(dtype))
+        buff.extend(self.encode_value(old_value, dtype))
+        dtype = self.get_type(new_value)
+        buff.extend(self.encode_byte(dtype))
+        buff.extend(self.encode_value(new_value, dtype))
+        self.send(buff)
+        logging.debug("edge attribute changed: %s", {
+            "source_id": source_id,
+            "time_id": time_id,
+            "edge_id": edge_id,
+            "attribute": attribute,
+            "old_value": old_value,
+            "new_value": new_value
+        })
+
+    def edge_attribute_removed(self, source_id, time_id, edge_id, attribute):
+        """An edge attribute was removed."""
+        if not source_id is self.source_id:
+            self.set_source_id(source_id)
+        buff = bytearray()
+        buff.extend(self.encode_byte(EVENT_DEL_EDGE_ATTR))
+        buff.extend(self.encode_string(source_id))
+        buff.extend(self.encode_long(time_id))
+        buff.extend(self.encode_string(edge_id))
+        buff.extend(self.encode_string(attribute))
+        self.send(buff)
+        logging.debug("edge attribute removed: %s", {
+            "source_id": source_id,
+            "time_id": time_id,
+            "edge_id": edge_id,
+            "attribute": attribute
+        })
 
 class NetStreamProxyGraph():
-   """ 
-   This is a utility class that handles 'source id' and 'time id' synchronization tokens. 
-   It proposes utile classes that allow to directly send events through the network pipe.
-   """
-   debug = True
-   sender = None
-   stream = None
-   source = None
-   _timeId = 0
-   
-   def __init__(self, *args, **kwargs):
-      """Constructor can be with one NetStreamSender object and a source id OR with with 4 args: Source ID, Stream ID, Host, and port number"""
-      if len(args) == 1 and isinstance(args[0], NetStreamSender):
-         if self.debug:
-            print("1 args, Initialize from sender object")
-         self.init_from_sender(("nss%d"%(1000*random())), args[0])
-      else:   
-         if len(args) == 2 and isinstance(args[0], types.StringType) and isinstance(args[1], NetStreamSender):
-            if self.debug:
-               print("2 args, Initialize from sender object")
-            self.init_from_sender(args[0], args[1])
-         else:
-            if len(args) == 4 and isinstance(args[0], types.StringType) and isinstance(args[1], types.StringType) and isinstance(args[2], types.StringType) and isinstance(args[3], types.IntType):
-               print("4 args, Initialize from args")
-               self.init_from_args(("nss%d"%(1000*random())),args[0], args[1], args[2], args[3])
-            else:
-               if len(args) == 5 and isinstance(args[0], types.StringType) and isinstance(args[1], types.StringType) and isinstance(args[2], types.StringType) and isinstance(args[3], types.StringType) and isinstance(args[4], types.IntType):
-                  print("5 args, Initialize from args")
-                  self.init_from_args(args[0], args[1], args[2], args[3], args[4])
-               else:
-                  print("Impossible to Initialize")
-   
-   def init_from_args(self, source, stream, host, port):
-     self.sender = DefaultNetSender(stream, host,port)
-     self.source = source
-   
-   def init_from_sender(self, source, sender):
-      self.sender = sender
-      self.source = source
-   
-   def addNode(self, node):
-       self.sender.nodeAdded(self.source, self._timeId, node)
-       self._timeId+=1
-   
-   def removeNode(self, node):
-       self.sender.nodeRemoved(self.source, self._timeId, node)
-       self._timeId+=1
-   
-   def addEdge(self, edge, from_node, to_node, directed):
-       self.sender.edgeAdded(self.source, self._timeId, edge, from_node, to_node, directed)
-       self._timeId+=1
-   
-   def removeEdge(self, edge):
-       self.sender.edgeRemoved(self.source, self._timeId, edge)
-       self._timeId+=1
-   
-   def addAttribute(self, attribute, value):
-       self.sender.graphAttributeAdded(self.source, self._timeId, attribute, value)
-       self._timeId+=1
-   
-   def removeAttribute(self, attribute):
-       self.sender.graphAttributeRemoved(self.source, self._timeId, attribute)
-       self._timeId+=1
-   
-   def changeAttribute(self, attribute, oldValue, newValue):
-       self.sender.graphAttributeChanged(self.source, self._timeId, attribute, oldValue, newValue)
-       self._timeId+=1
-   
-   def addNodeAttribute(self, node, attribute, value):
-       self.sender.nodeAttributeAdded(self.source, self._timeId, node, attribute, value)
-       self._timeId+=1
-   
-   def removeNodeAttibute(self, node, attribute):
-       self.sender.nodeAttributeRemoved(self.source, self._timeId, node, attribute)
-       self._timeId+=1
-   
-   def changeNodeAttribute(self, node, attribute, oldValue, newValue):
-       self.sender.nodeAttributeChanged(self.source, self._timeId, node, attribute, oldValue, newValue)
-       self._timeId+=1
-   
-   def addEdgeAttribute(self, edge, attribute, value):
-       self.sender.edgeAttributeAdded(self.source, self._timeId, edge, attribute, value)
-       self._timeId+=1
-   
-   def removeEdgeAttribute(self, edge, attribute):
-       self.sender.edgeAttributeRemoved(self.source, self._timeId, edge, attribute)
-       self._timeId+=1
-   
-   def changeEdgeAttrivute(self, edge, attribute, oldValue, newValue):
-       self.sender.edgeAttributeChanged(self.source, self._timeId, edge, attribute, oldValue, newValue)
-       self._timeId+=1
-   
-   def clearGraph(self):
-       self.sender.graphCleared(self.source, self._timeId)
-       self._timeId+=1
-   
-   def stepBegins(self, time):
-       self.sender.stepBegins(self.source, self._timeId, time)
-       self._timeId+=1
-   
-def example():
-  """docstring for main"""
-  
-  stream = NetStreamSender(Base64NetStreamTransport("default","localhost",2001))
-  
-  source_id="xxx"
-  time_id=0L
-  ss = "node{fill-mode:plain;fill-color:#567;size:6px;}";
-  
-  stream.graphAttributeAdded(source_id, time_id,"stylesheet", ss);time_id+=1;
-  stream.graphAttributeAdded(source_id, time_id,"ui.antialias", True);time_id+=1;
-  stream.graphAttributeAdded(source_id, time_id,"test", "foo");time_id+=1;
-  stream.graphAttributeChanged(source_id, time_id,"test", "foo", False);time_id+=1;
-  stream.graphAttributeAdded(source_id, time_id,"layout.stabilization-limit", 0);time_id+=1;
-  for i in range(0,500):
-    stream.nodeAdded(source_id, time_id,str(i));time_id+=1;
-    if(i>0):
-      stream.edgeAdded(source_id, time_id,str(i)+"_"+str(i-1), str(i), str(i-1),False);time_id+=1;
-      stream.edgeAdded(source_id, time_id,str(i)+"__"+str(i/2), str(i), str(i/2), False);time_id+=1;
+    """
+    This is a utility class that handles 'source id' and 'time id' synchronization tokens.
+    It proposes utile classes that allow to directly send events through the network pipe.
+    """
 
-def testEvents():
-  source_id="xxx"
-  time_id=0L
-  stream = NetStreamSender("default","localhost",2001)
-  stream.nodeAdded(source_id, time_id, "node0");time_id+=1;
-  stream.edgeAdded(source_id, time_id,"edge", "node0", "node1", True);time_id+=1;
-  stream.nodeAttributeAdded(source_id, time_id, "node0","nodeAttribute", 0);time_id+=1;
-  stream.nodeAttributeChanged(source_id, time_id, "node0","nodeAttribute",0, 1);time_id+=1;
-  stream.nodeAttributeRemoved(source_id, time_id, "node0","nodeAttribute");time_id+=1;
-  stream.edgeAttributeAdded(source_id, time_id, "edge","edgeAttribute", 0);time_id+=1;
-  stream.edgeAttributeChanged(source_id, time_id, "edge","edgeAttribute",0, 1);time_id+=1;
-  stream.edgeAttributeRemoved(source_id, time_id, "edge","edgeAttribute");time_id+=1;
-  stream.graphAttributeAdded(source_id, time_id, "graphAttribute", 0);time_id+=1;
-  stream.graphAttributeChanged(source_id, time_id, "graphAttribute",0, 1);time_id+=1;
-  stream.graphAttributeRemoved(source_id, time_id, "graphAttribute");time_id+=1;
-  stream.stepBegins(source_id, time_id, 1.1);time_id+=1;
-  stream.edgeRemoved(source_id, time_id, "edge");time_id+=1;
-  stream.nodeRemoved(source_id, time_id,"node0");time_id+=1;
-  stream.graphCleared(source_id, time_id);time_id+=1;
+    def __init__(self, sender, source_id=None):
+        """Constructor can be with one NetStreamSender object and a source id OR with with 4 args: Source ID, Stream ID, Host, and port number"""
+        self.sender = sender
+        self.source_id = source_id if source_id else "nss%d" % (1000 * random())
+        self.time_id = 0
 
-def testTypes():
-  source_id="xxx"
-  time_id=0L
-  nsc = NetStreamSender("default","localhost", 2001)
-  nsc.graphAttributeAdded(source_id, time_id, "intArray", [0, 1, 2]);time_id+=1;
-  nsc.graphAttributeAdded(source_id, time_id, "doubleArray", [0.0,1.1,2.2]);time_id+=1;
-  nsc.graphAttributeAdded(source_id, time_id, "longArray", [0L,1L,2L]);time_id+=1;
-  nsc.graphAttributeAdded(source_id, time_id, "booleanArray", [True, False]);time_id+=1;
-  nsc.graphAttributeAdded(source_id, time_id, "int", 1);time_id+=1;
-  nsc.graphAttributeAdded(source_id, time_id, "double", 1.0);time_id+=1;
-  nsc.graphAttributeAdded(source_id, time_id, "long", 1L);time_id+=1;
-  nsc.graphAttributeAdded(source_id, time_id, "boolean", True);time_id+=1;
-  nsc.graphAttributeAdded(source_id, time_id, "string", "true");time_id+=1;
+    def add_node(self, node):
+        """Add a node to the graph."""
+        self.sender.node_added(self.source_id, self.time_id, node)
+        self.time_id += 1
 
-if __name__ == "__main__":
-    example()
+    def remove_node(self, node):
+        """Remove a node from the graph."""
+        self.sender.node_removed(self.source_id, self.time_id, node)
+        self.time_id += 1
+
+    def add_edge(self, edge, from_node, to_node, directed=False):
+        """Add an edge to the graph."""
+        self.sender.edge_added(self.source_id, self.time_id, edge, from_node, to_node, directed)
+        self.time_id += 1
+
+    def remove_edge(self, edge):
+        """Remove an edge from the graph."""
+        self.sender.edge_removed(self.source_id, self.time_id, edge)
+        self.time_id += 1
+
+    def add_attribute(self, attribute, value):
+        """Add an attribute to the graph."""
+        self.sender.graph_attribute_added(self.source_id, self.time_id, attribute, value)
+        self.time_id += 1
+
+    def remove_attribute(self, attribute):
+        """Remove an attribute from the graph."""
+        self.sender.graph_attribute_removed(self.source_id, self.time_id, attribute)
+        self.time_id += 1
+
+    def change_attribute(self, attribute, old_value, new_value):
+        """Change an attribute of the graph."""
+        self.sender.graph_attribute_changed(self.source_id, self.time_id, attribute, old_value, new_value)
+        self.time_id += 1
+
+    def add_node_attribute(self, node, attribute, value):
+        """Add an attribute to a node."""
+        self.sender.node_attribute_added(self.source_id, self.time_id, node, attribute, value)
+        self.time_id += 1
+
+    def remove_node_attibute(self, node, attribute):
+        """Remove an attribute from a node."""
+        self.sender.node_attribute_removed(self.source_id, self.time_id, node, attribute)
+        self.time_id += 1
+
+    def change_node_attribute(self, node, attribute, old_value, new_value):
+        """Change an attribute of a node."""
+        self.sender.node_attribute_changed(self.source_id, self.time_id, node, attribute, old_value, new_value)
+        self.time_id += 1
+
+    def add_edge_attribute(self, edge, attribute, value):
+        """Add an attribute to an edge."""
+        self.sender.edge_attribute_added(self.source_id, self.time_id, edge, attribute, value)
+        self.time_id += 1
+
+    def remove_edge_attribute(self, edge, attribute):
+        """Remove an attribute from an edge."""
+        self.sender.edge_attribute_removed(self.source_id, self.time_id, edge, attribute)
+        self.time_id += 1
+
+    def change_edge_attribute(self, edge, attribute, old_value, new_value):
+        """Change an attribute of an edge."""
+        self.sender.edge_attribute_changed(self.source_id, self.time_id, edge, attribute, old_value, new_value)
+        self.time_id += 1
+
+    def clear_graph(self):
+        """Clear the graph."""
+        self.sender.graph_cleared(self.source_id, self.time_id)
+        self.time_id += 1
+
+    def step_begins(self, time):
+        """Begin a step."""
+        self.sender.step_begun(self.source_id, self.time_id, time)
+        self.time_id += 1

--- a/python/gs_netstream/varint.py
+++ b/python/gs_netstream/varint.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+"""Implementation for encoding unsigned varints."""
+
+def encoding_size(value):
+    """Computes the encoding size of a value."""
+    if value < (1L << 7):
+        return 1
+    if value < (1L << 14):
+        return 2
+    if value < (1L << 21):
+        return 3
+    if value < (1L << 28):
+        return 4
+    if value < (1L << 35):
+        return 5
+    if value < (1L << 42):
+        return 6
+    if value < (1L << 49):
+        return 7
+    if value < (1L << 56):
+        return 8
+    return 9
+
+def encode_unsigned(value):
+    """Encodes a Python integer into its varint representation."""
+    if not isinstance(value, int) or value < 0:
+        raise TypeError("value argument is not an integer or is negative")
+    size = encoding_size(value)
+    buff = bytearray(size)
+    for i in xrange(size):
+        head = 128
+        if i == size - 1:
+            head = 0
+        buff[i] = (((value >> (7 * i)) & 127) ^ head) & 255
+    return buff


### PR DESCRIPTION
Hello,
I heavily refactored the python sender module with the following important changes:

* Made the code more readable and pythonic.
* Removed the Base64 Transport.
* Added varint support to work with the latest gs-core version (1.2).
* Made some optimisations (bufferarray instead of strings).

I tested the new version against gs-core and works fine (so far). I hope merge my pull request for others to be able to use NetStream with Python.

Thanks for the wonderful work in GraphStream!
Hugo.