### PR TITLE
Avoid conflicts between functional's std::bind and sys/socket.h's bind

### DIFF
--- a/c++/src/netstream-socket.cpp
+++ b/c++/src/netstream-socket.cpp
@@ -257,7 +257,7 @@ namespace netstream
 			self.sin_addr.s_addr = htonl(INADDR_ANY);
 
 			// Assign a port number to the socket
-			if ( bind(server_socket_, (struct sockaddr*)&self, sizeof(self)) != 0 )
+			if ( ::bind(server_socket_, (struct sockaddr*)&self, sizeof(self)) != 0 )
 				BailOnNetStreamSocketError("netstream::NetStreamSocket::accept() Unable to create listening socket");
 
 


### PR DESCRIPTION
On some platforms (such as macOS 10.13) the use of `using namespace std` and 
the transitive inclusion of the C++11's functional header can create a conflict between std::bind
and the bind function provided by sys/socket.h . Explicitly indicating that we want to call 
the bind from the global namespace ensures that we avoid the problem.